### PR TITLE
Logging Infrastructure and Timing Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 # Rust
 target/
 Cargo.lock
+
+logs/*.log

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,7 @@ robstride = { version = "0.3.6", features = ["instant_command"] }
 imu = "0.7.5"
 eyre = "0.6"
 tracing = "0.1"
-tracing-subscriber = "0.3.19"
+tracing-subscriber = {version = "0.3.19", features=["time"]}
+uuid = { version = "1.6.1", features = ["v4"] }
+tracing-appender = "0.2.3"
+time = {version="0.3.41", features=["macros"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ tracing-subscriber = {version = "0.3.19", features=["time"]}
 uuid = { version = "1.6.1", features = ["v4"] }
 tracing-appender = "0.2.3"
 time = {version="0.3.41", features=["macros"]}
+nix = "0.26"

--- a/src/actuators.rs
+++ b/src/actuators.rs
@@ -6,6 +6,7 @@ use robstride::{
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
+use tracing::trace;
 
 #[derive(Clone, Copy, Debug)]
 pub struct ActuatorCommand {
@@ -129,6 +130,8 @@ impl Actuator {
         &self,
         commands: Vec<ActuatorCommand>,
     ) -> Result<Vec<ActionResult>> {
+        let uuid = uuid::Uuid::new_v4();
+        trace!("actuator::command_actuators::START uuid={}", uuid);
         let mut results = vec![];
         let mut supervisor = self.supervisor.lock().await;
 
@@ -153,10 +156,13 @@ impl Actuator {
             });
         }
 
+        trace!("actuator::command_actuators::END uuid={}", uuid);
         Ok(results)
     }
 
     pub async fn configure_actuator(&self, config: ConfigureRequest) -> Result<ActionResponse> {
+        let uuid = uuid::Uuid::new_v4();
+        trace!("actuator::configure_actuator::START uuid={}", uuid);
         let motor_id = config.actuator_id as u8;
         let mut supervisor = self.supervisor.lock().await;
 
@@ -186,6 +192,7 @@ impl Actuator {
             supervisor.change_id(motor_id, new_id as u8).await?;
         }
 
+        trace!("actuator::configure_actuator::END uuid={}", uuid);
         Ok(ActionResponse {
             success: result.is_ok(),
             error: result.err().map(|e| e.to_string()),
@@ -193,14 +200,19 @@ impl Actuator {
     }
 
     pub async fn trigger_actuator_read(&self, actuator_ids: Vec<u32>) -> Result<()> {
+        let uuid = uuid::Uuid::new_v4();
+        trace!("actuator::trigger_actuator_read::START uuid={}", uuid);
         let supervisor = self.supervisor.lock().await;
         for id in actuator_ids {
             supervisor.request_feedback(id as u8).await?;
         }
+        trace!("actuator::trigger_actuator_read::END uuid={}", uuid);
         Ok(())
     }
 
     pub async fn get_actuators_state(&self, actuator_ids: Vec<u32>) -> Result<Vec<ActuatorState>> {
+        let uuid = uuid::Uuid::new_v4();
+        trace!("actuator::get_actuators_state::START uuid={}", uuid);
         let mut responses = vec![];
 
         // Reads the latest feedback from each actuator.
@@ -227,6 +239,7 @@ impl Actuator {
                 });
             }
         }
+        trace!("actuator::get_actuators_state::END uuid={}", uuid);
         Ok(responses)
     }
 

--- a/src/bin/runtime.rs
+++ b/src/bin/runtime.rs
@@ -3,9 +3,12 @@ use ::kinfer::model::ModelRunner;
 use ::std::path::Path;
 use ::std::sync::Arc;
 
-use kinfer_kbot::initialize_logging;
-use kinfer_kbot::provider::KBotProvider;
-use kinfer_kbot::runtime::ModelRuntime;
+use kinfer_kbot::{
+    initialize_file_and_console_logging,
+    initialize_logging,
+    provider::KBotProvider,
+    runtime::ModelRuntime,
+};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -28,13 +31,21 @@ struct Args {
     /// Torque scale
     #[arg(long, default_value_t = 1.0)]
     torque_scale: f32,
+    /// File logging
+    #[arg(long, default_value = "false")]
+    file_logging: bool,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    initialize_logging();
-
     let args = Args::parse();
+
+    if args.file_logging {
+        initialize_file_and_console_logging();
+    } else {
+        initialize_logging();
+    }
+
     let model_path = Path::new(&args.model_path);
 
     let model_provider = Arc::new(KBotProvider::new(args.torque_enabled, args.torque_scale).await?);

--- a/src/imu.rs
+++ b/src/imu.rs
@@ -1,7 +1,7 @@
 use ::eyre::Result;
 use ::imu::{HiwonderOutput, HiwonderReader, ImuFrequency, ImuReader};
 use ::std::time::Duration;
-use ::tracing::{error, info};
+use ::tracing::{trace, error, info};
 
 const IMU_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -88,6 +88,8 @@ impl IMU {
     }
 
     pub async fn get_values(&self) -> Result<IMUData> {
+        let uuid = uuid::Uuid::new_v4();
+        trace!("IMU log::get_values::START uuid={}", uuid);
         let direct_read = self.imu_reader.get_data()?;
         let accel = match direct_read.accelerometer {
             Some(accel) => accel,
@@ -101,7 +103,7 @@ impl IMU {
             Some(quat) => quat,
             None => return Err(eyre::eyre!("Failed to read quaternion")),
         };
-
+        trace!("IMU log::get_values::END uuid={}", uuid);
         Ok(IMUData {
             accel_x: accel.x,
             accel_y: accel.y,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,11 @@
 use ::tracing_subscriber::FmtSubscriber;
+use time::macros::format_description;
+use tracing::info;
+use tracing_subscriber::{
+    fmt::{format::FmtSpan, time::UtcTime},
+    prelude::*,
+    EnvFilter,
+};
 
 pub mod actuators;
 pub mod constants;
@@ -11,4 +18,48 @@ pub fn initialize_logging() {
         .with_max_level(tracing::Level::INFO)
         .finish();
     tracing::subscriber::set_global_default(subscriber).expect("Setting default subscriber failed");
+}
+
+pub fn initialize_file_and_console_logging() {
+    let log_dir = std::path::PathBuf::from("logs");
+    std::fs::create_dir_all(&log_dir).expect("Failed to create logs directory");
+
+    let file_appender = tracing_appender::rolling::never(log_dir, "kbot.log");
+
+    let timer = UtcTime::new(format_description!(
+        "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:6]Z"
+    ));
+
+    let file_layer = tracing_subscriber::fmt::layer()
+        .with_writer(file_appender)
+        .with_timer(timer.clone())
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_thread_names(true)
+        .with_file(true)
+        .with_line_number(true)
+        .with_level(true)
+        .with_span_events(FmtSpan::CLOSE)
+        .with_ansi(false)
+        .with_filter(EnvFilter::new("info,kinfer_kbot=debug"));
+
+    let console_layer = tracing_subscriber::fmt::layer()
+        .with_timer(timer)
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_thread_names(true)
+        .with_file(true)
+        .with_line_number(true)
+        .with_level(true)
+        .with_span_events(FmtSpan::CLOSE)
+        .with_ansi(true)
+        .with_filter(EnvFilter::new("info"));
+
+    let subscriber = tracing_subscriber::registry()
+        .with(file_layer)
+        .with(console_layer);
+
+    tracing::subscriber::set_global_default(subscriber).expect("Failed to set tracing subscriber");
+
+    info!("Logging initialized - writing to logs/kbot.log");
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -226,7 +226,6 @@ impl ModelProvider for KBotProvider {
 
     async fn get_accelerometer(&self) -> Result<Array<f32, IxDyn>, ModelError> {
         let uuid = uuid::Uuid::new_v4();
-        trace!("provider::get_accelerometer::START uuid={}", uuid);
         let values = self
             .imu
             .get_values()

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -3,6 +3,7 @@ use ::imu::{Quaternion, Vector3};
 use ::kinfer::{ModelError, ModelProvider};
 use ::ndarray::{Array, IxDyn};
 use ::std::time::{Duration, Instant};
+use tracing::debug;
 
 use crate::actuators::{Actuator, ActuatorCommand, ActuatorState, ConfigureRequest};
 use crate::constants::{ACTUATOR_KP_KD, ACTUATOR_NAME_TO_ID, HOME_POSITION};
@@ -78,13 +79,20 @@ impl KBotProvider {
         &self,
         actuator_ids: &[u32],
     ) -> Result<Vec<ActuatorState>, ModelError> {
-        self.actuators
+        let uuid = uuid::Uuid::new_v4();
+        debug!("provider::get_actuator_state::START uuid={}", uuid);
+        let result = self
+            .actuators
             .get_actuators_state(actuator_ids.to_vec())
             .await
-            .map_err(|e| ModelError::Provider(e.to_string()))
+            .map_err(|e| ModelError::Provider(e.to_string()));
+        debug!("provider::get_actuator_state::END uuid={}", uuid);
+        result
     }
 
     pub async fn trigger_actuator_read(&self) -> Result<(), ModelError> {
+        let uuid = uuid::Uuid::new_v4();
+        debug!("provider::trigger_actuator_read::START uuid={}", uuid);
         let actuator_ids = ACTUATOR_NAME_TO_ID
             .iter()
             .map(|(_, id)| *id)
@@ -93,6 +101,7 @@ impl KBotProvider {
             .trigger_actuator_read(actuator_ids)
             .await
             .map_err(|e| ModelError::Provider(e.to_string()))?;
+        debug!("provider::trigger_actuator_read::END uuid={}", uuid);
         Ok(())
     }
 
@@ -121,6 +130,8 @@ impl ModelProvider for KBotProvider {
         &self,
         joint_names: &[String],
     ) -> Result<Array<f32, IxDyn>, ModelError> {
+        let uuid = uuid::Uuid::new_v4();
+        debug!("provider::get_joint_angles::START uuid={}", uuid);
         let actuator_ids = self.get_actuator_ids(joint_names)?;
         let actuator_state = self.get_actuator_state(&actuator_ids).await?;
 
@@ -140,7 +151,7 @@ impl ModelProvider for KBotProvider {
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
-
+        debug!("provider::get_joint_angles::END uuid={}", uuid);
         Ok(Array::from_shape_vec((joint_names.len(),), joint_angles)
             .map_err(|e| ModelError::Provider(e.to_string()))?
             .into_dyn())
@@ -150,6 +161,11 @@ impl ModelProvider for KBotProvider {
         &self,
         joint_names: &[String],
     ) -> Result<Array<f32, IxDyn>, ModelError> {
+        let uuid = uuid::Uuid::new_v4();
+        debug!(
+            "provider::get_joint_angular_velocities::START uuid={}",
+            uuid
+        );
         let actuator_ids = self.get_actuator_ids(joint_names)?;
         let actuator_state = self.get_actuator_state(&actuator_ids).await?;
 
@@ -169,7 +185,10 @@ impl ModelProvider for KBotProvider {
                 })
             })
             .collect::<Result<Vec<f32>, ModelError>>()?;
-
+        debug!(
+            "provider::get_joint_angular_velocities::END uuid={}",
+            uuid
+        );
         Ok(
             Array::from_shape_vec((joint_names.len(),), joint_angular_velocities)
                 .map_err(|e| ModelError::Provider(e.to_string()))?
@@ -178,6 +197,8 @@ impl ModelProvider for KBotProvider {
     }
 
     async fn get_projected_gravity(&self) -> Result<Array<f32, IxDyn>, ModelError> {
+        let uuid = uuid::Uuid::new_v4();
+        debug!("provider::get_projected_gravity::START uuid={}", uuid);
         let values = self
             .imu
             .get_values()
@@ -190,6 +211,7 @@ impl ModelProvider for KBotProvider {
             w: values.quat_w,
         }
         .rotate_vector(Vector3::new(0.0, 0.0, -9.81), true);
+        debug!("provider::get_projected_gravity::END uuid={}", uuid);
         Ok(Array::from_shape_vec(
             (3,),
             vec![
@@ -203,6 +225,8 @@ impl ModelProvider for KBotProvider {
     }
 
     async fn get_accelerometer(&self) -> Result<Array<f32, IxDyn>, ModelError> {
+        let uuid = uuid::Uuid::new_v4();
+        trace!("provider::get_accelerometer::START uuid={}", uuid);
         let values = self
             .imu
             .get_values()
@@ -273,8 +297,6 @@ impl ModelProvider for KBotProvider {
             .command_actuators(commands)
             .await
             .map_err(|e| ModelError::Provider(e.to_string()))?;
-
-        println!("took action {:?} at time {:?}", action, Instant::now());
 
         Ok(())
     }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -3,7 +3,7 @@ use ::imu::{Quaternion, Vector3};
 use ::kinfer::{ModelError, ModelProvider};
 use ::ndarray::{Array, IxDyn};
 use ::std::time::{Duration, Instant};
-use tracing::debug;
+use tracing::{trace, debug};
 
 use crate::actuators::{Actuator, ActuatorCommand, ActuatorState, ConfigureRequest};
 use crate::constants::{ACTUATOR_KP_KD, ACTUATOR_NAME_TO_ID, HOME_POSITION};
@@ -106,6 +106,8 @@ impl KBotProvider {
     }
 
     pub async fn move_to_home(&self) -> Result<(), ModelError> {
+        let uuid = uuid::Uuid::new_v4();
+        trace!("provider::move_to_home::START uuid={}", uuid);
         let home_position = HOME_POSITION;
         let mut commands = vec![];
         for (id, position) in home_position {
@@ -120,6 +122,7 @@ impl KBotProvider {
             .command_actuators(commands)
             .await
             .map_err(|e| ModelError::Provider(e.to_string()))?;
+        trace!("provider::move_to_home::END uuid={}", uuid);
         Ok(())
     }
 }
@@ -226,6 +229,7 @@ impl ModelProvider for KBotProvider {
 
     async fn get_accelerometer(&self) -> Result<Array<f32, IxDyn>, ModelError> {
         let uuid = uuid::Uuid::new_v4();
+        trace!("provider::get_accelerometer::START uuid={}", uuid);
         let values = self
             .imu
             .get_values()
@@ -234,12 +238,15 @@ impl ModelProvider for KBotProvider {
         let accel_x = values.accel_x as f32;
         let accel_y = values.accel_y as f32;
         let accel_z = values.accel_z as f32;
+        trace!("provider::get_accelerometer::END uuid={}", uuid);
         Ok(Array::from_shape_vec((3,), vec![accel_x, accel_y, accel_z])
             .map_err(|e| ModelError::Provider(e.to_string()))?
             .into_dyn())
     }
 
     async fn get_gyroscope(&self) -> Result<Array<f32, IxDyn>, ModelError> {
+        let uuid = uuid::Uuid::new_v4();
+        trace!("provider::get_gyroscope::START uuid={}", uuid);
         let values = self
             .imu
             .get_values()
@@ -248,6 +255,7 @@ impl ModelProvider for KBotProvider {
         let gyro_x = values.gyro_x as f32;
         let gyro_y = values.gyro_y as f32;
         let gyro_z = values.gyro_z as f32;
+        trace!("provider::get_gyroscope::END uuid={}", uuid);
         Ok(Array::from_shape_vec((3,), vec![gyro_x, gyro_y, gyro_z])
             .map_err(|e| ModelError::Provider(e.to_string()))?
             .into_dyn())
@@ -267,6 +275,8 @@ impl ModelProvider for KBotProvider {
         action: Array<f32, IxDyn>,
     ) -> Result<(), ModelError> {
         assert_eq!(joint_names.len(), action.len());
+        let uuid = uuid::Uuid::new_v4();
+        trace!("provider::take_action::START uuid={}", uuid);
 
         let commands: Vec<ActuatorCommand> = joint_names
             .iter()
@@ -297,6 +307,7 @@ impl ModelProvider for KBotProvider {
             .await
             .map_err(|e| ModelError::Provider(e.to_string()))?;
 
+        trace!("provider::take_action::END uuid={}", uuid);
         Ok(())
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,13 +4,13 @@ use ::std::sync::Arc;
 use ::std::time::Duration;
 use std::time::SystemTime;
 use ::tokio::runtime::Runtime;
-use ::tokio::time::{interval, sleep};
+use ::tokio::time::sleep;
 use tracing::debug;
 
 use crate::actuators::ActuatorCommand;
 use crate::constants::HOME_POSITION;
 use crate::provider::KBotProvider;
-
+use nix::sys::timerfd::{TimerFd, ClockId, TimerFlags, Expiration, TimerSetTimeFlags};
 // We trigger a read N milliseconds before reading the current actuator state,
 // to account for the asynchronicity of the CAN RX buffer.
 const TRIGGER_READ_BEFORE: Duration = Duration::from_millis(2);
@@ -90,15 +90,26 @@ impl ModelRuntime {
                 .map_err(|e| ModelError::Provider(e.to_string()))?;
 
             // Wait for the first tick, since it happens immediately.
-            let mut read_interval = interval(dt);
-            let mut command_interval = interval(dt);
+            let read_interval = TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty()).unwrap();
+            read_interval.set(Expiration::Interval(dt.into()), TimerSetTimeFlags::empty()).map_err(|e| {
+                ModelError::Provider(format!("Failed to set timer: {}", e))
+            })?;
+
+            let command_interval = TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty()).unwrap();
+            command_interval.set(Expiration::Interval(dt.into()), TimerSetTimeFlags::empty()).map_err(|e| {
+                ModelError::Provider(format!("Failed to set timer: {}", e))
+            })?;
 
             // Start the two intervals N milliseconds apart. The first tick is
             // always instantaneous and represents the start of the interval
             // ticks.
-            read_interval.tick().await;
+            read_interval.wait().map_err(|e| {
+                ModelError::Provider(format!("Failed to wait for timer: {}", e))
+            })?;
             sleep(dt - TRIGGER_READ_BEFORE).await;
-            command_interval.tick().await;
+            command_interval.wait().map_err(|e| {
+                ModelError::Provider(format!("Failed to wait for timer: {}", e))
+            })?;
 
             while running.load(Ordering::Relaxed) {
                 let uuid = uuid::Uuid::new_v4();
@@ -128,9 +139,13 @@ impl ModelRuntime {
                     // Trigger an actuator read N milliseconds before the next
                     // command tick, to make sure the observations are as fresh
                     // as possible.
-                    read_interval.tick().await;
+                    read_interval.wait().map_err(|e| {
+                        ModelError::Provider(format!("Failed to wait for timer: {}", e))
+                    })?;
                     model_provider.trigger_actuator_read().await?;
-                    command_interval.tick().await;
+                    command_interval.wait().map_err(|e| {
+                        ModelError::Provider(format!("Failed to wait for timer: {}", e))
+                    })?;
                 }
 
                 joint_positions = output;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2,8 +2,10 @@ use ::kinfer::model::{ModelError, ModelRunner};
 use ::std::sync::atomic::{AtomicBool, Ordering};
 use ::std::sync::Arc;
 use ::std::time::Duration;
+use std::time::SystemTime;
 use ::tokio::runtime::Runtime;
 use ::tokio::time::{interval, sleep};
+use tracing::debug;
 
 use crate::actuators::ActuatorCommand;
 use crate::constants::HOME_POSITION;
@@ -99,11 +101,18 @@ impl ModelRuntime {
             command_interval.tick().await;
 
             while running.load(Ordering::Relaxed) {
+                let uuid = uuid::Uuid::new_v4();
+                let uuid_main_control_loop = uuid::Uuid::new_v4();
+                let start = SystemTime::now();
+                debug!("runtime::model_runner_step::START uuid={}", uuid);
+                debug!("runtime::main_control_loop::START uuid={}", uuid_main_control_loop);
+
                 let (output, next_carry) = model_runner
                     .step(carry)
                     .await
                     .map_err(|e| ModelError::Provider(e.to_string()))?;
                 carry = next_carry;
+                debug!("runtime::model_runner_step::END uuid={}, elapsed: {:?}", uuid, start.elapsed());
 
                 for i in 1..(slowdown_factor + 1) {
                     if !running.load(Ordering::Relaxed) {
@@ -125,6 +134,7 @@ impl ModelRuntime {
                 }
 
                 joint_positions = output;
+                debug!("runtime::main_control_loop::END uuid={}, elapsed: {:?}", uuid_main_control_loop, start.elapsed());
             }
             Ok::<(), ModelError>(())
         });


### PR DESCRIPTION
# Intoduction

We lack logging for timing data. Add this feature

Also use timerfd instead of `tokio::time::interval` as that can cause rounding errors' inside tokio's timerwheel.

# Testing

We use realtime priority for the task

```
sudo chrt -f 80 ./target/release/runtime --model-path examples/kbot_standing.kinfer --magnitude-factor 0.2 --torque-scale 0.1 --dt 20 --file-logging --torque-enabled
```

We see much tighter timing with these changes.